### PR TITLE
Added svg mime type for deflate module

### DIFF
--- a/src/AppserverIo/WebServer/Modules/DeflateModule.php
+++ b/src/AppserverIo/WebServer/Modules/DeflateModule.php
@@ -64,7 +64,8 @@ class DeflateModule implements HttpModuleInterface
         "text/xml",
         "application/xml",
         "application/xml+rss",
-        "text/javascript"
+        "text/javascript",
+        "image/svg+xml"
     );
 
     /**


### PR DESCRIPTION
In order to not wait for implementation of https://github.com/appserver-io/webserver/issues/186 I added svg mime type hard coded in the current as-is implementation.